### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -61,7 +61,7 @@ class syntax_plugin_clippy extends DokuWiki_Syntax_Plugin {
    * @param Doku_Handler $handler The handler
    * @return array Data for the renderer
    */
-  public function handle( $match, $state, $pos, Doku_Handler &$handler ) {
+  public function handle( $match, $state, $pos, Doku_Handler $handler ) {
     // <object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" width="110" height="14" class="clippy" >
     //   <param name="movie" value="lib/clippy.swf"/>
     //   <param name="allowScriptAccess" value="always" />
@@ -112,7 +112,7 @@ class syntax_plugin_clippy extends DokuWiki_Syntax_Plugin {
    * @param array   $data     The data from the handler() function
    * @return bool If rendering was successful.
    */
-  public function render( $mode, Doku_Renderer &$renderer, $data ) {
+  public function render( $mode, Doku_Renderer $renderer, $data ) {
     if ( $mode != 'xhtml' ) return false;
     $movie = "lib/clippy.swf";
     $flashvars = array( "text" => $data['text'] );


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
